### PR TITLE
chore: atualiza a URL base da API do Bling

### DIFF
--- a/src/providers/ioc.ts
+++ b/src/providers/ioc.ts
@@ -8,7 +8,7 @@ import { IBlingRepository } from '../repositories/bling.repository.interface'
  */
 export function getRepository(accessToken: string): IBlingRepository {
   return new BlingRepository({
-    baseUrl: 'https://www.bling.com.br/Api/v3',
+    baseUrl: 'https://api.bling.com.br/Api/v3',
     accessToken
   })
 }


### PR DESCRIPTION
fix #33

O Bling recentemente enviou comunicação informando sobre a mudança da URL base da API de
https://bling.com.br/Api/v3 para https://api.bling.com.br/Api/v3