### PR TITLE
feat: adiciona o parâmetro opcional `baseUrl` no construtor da classe `Bling`

### DIFF
--- a/src/bling.ts
+++ b/src/bling.ts
@@ -65,8 +65,11 @@ export default class Bling {
    *
    * @param accessToken O token de acesso à API do Bling.
    */
-  constructor(accessToken: string) {
-    this.#repository = getRepository(accessToken)
+  constructor(
+    accessToken: string,
+    baseUrl = 'https://api.bling.com.br/Api/v3'
+  ) {
+    this.#repository = getRepository(accessToken, baseUrl)
     this.#modules = {}
   }
 

--- a/src/providers/ioc.ts
+++ b/src/providers/ioc.ts
@@ -6,9 +6,12 @@ import { IBlingRepository } from '../repositories/bling.repository.interface'
  *
  * @returns {IBlingRepository}
  */
-export function getRepository(accessToken: string): IBlingRepository {
+export function getRepository(
+  accessToken: string,
+  baseUrl: string
+): IBlingRepository {
   return new BlingRepository({
-    baseUrl: 'https://www.bling.com.br/Api/v3',
+    baseUrl,
     accessToken
   })
 }


### PR DESCRIPTION
fix #33

Esse novo parâmetro opcional possibilita a mudança da URL base utilizada no método `getRepository` em tempo de instanciação da classe principal `Bling`. É útil para mudanças futuras na URL base como aconteceu recentemente por parte do Bling ou para testes.

Esse PR também já atualiza o valor padrão da URL base para o divulgado recentemente pelo Bling de `https://bling.com.br/Api/v3` para `https://api.bling.com.br/Api/v3`